### PR TITLE
fix: fix esm export errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextra-synced-tabs",
-  "version": "0.1.0",
+  "version": "0.0.0-semantic-relase",
   "description": "Synchronize selected tabs in your Nextra site and store the selected index in local storage",
   "license": "MIT",
   "author": "UserHub (https://userhub.com/)",
@@ -12,27 +12,23 @@
   "bugs": {
     "url": "https://github.com/userhubdev/nextra-synced-tabs/issues"
   },
-  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
-    },
-    "./package.json": "./package.json"
+    }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
   "files": [
     "/dist"
   ],
   "scripts": {
-    "build": "tsup src/index.tsx --out-dir dist --format esm,cjs --dts --minify --clean",
+    "build": "tsup",
     "check-types": "tsc --noEmit --incremental --tsBuildInfoFile .typescript/tsconfig.tsbuildinfo",
     "dev": "tsup src/index.tsx --out-dir dist --format esm,cjs --dts --watch --clean",
     "prepare": "husky install",
     "validate": "prettier --check . && tsc --noEmit"
   },
+  "types": "dist/index.d.ts",
   "dependencies": {
     "usehooks-ts": "^2.9.1"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { Tab, Tabs } from "nextra-theme-docs";
+import { Tabs, Tab } from "nextra-theme-docs";
 import * as React from "react";
 import { useIsClient, useLocalStorage } from "usehooks-ts";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,17 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Default",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["esnext", "dom", "dom.iterable"],
+    "target": "es2016",
+    "module": "ESNext",
+    "declaration": false,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "allowJs": true,
     "jsx": "react",
     "moduleResolution": "node",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true,
-    "strict": true
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+import tsconfig from "./tsconfig.json";
+
+export default defineConfig({
+  name: "nextra-synced-tabs",
+  entry: ["src/index.tsx"],
+  format: "esm",
+  dts: true,
+  clean: true,
+  minify: true,
+  outExtension: () => ({ js: ".js" }),
+  target: tsconfig.compilerOptions.target,
+});


### PR DESCRIPTION
🙃 Fixes this error when building in Next.js:

```
SyntaxError: Named export 'useIsClient' not found. The requested module 'usehooks-ts' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'usehooks-ts';
```

Also fixes type resolution in VSCode.